### PR TITLE
Add ConfigSource

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,12 +25,18 @@ func (self ConfigService) Path() string {
 func (self ConfigService) Value() interface{} {
     return nil
 }
+func (self ConfigService) Source() ConfigSource {
+    return self.ConfigSource
+}
 
 func (self ConfigServiceFrontend) Path() string {
     return makePath("services", self.ServiceName, "frontend")
 }
 func (self ConfigServiceFrontend) Value() interface{} {
     return self.Frontend
+}
+func (self ConfigServiceFrontend) Source() ConfigSource {
+    return self.ConfigSource
 }
 
 func (self ConfigServiceBackend) Path() string {
@@ -39,10 +45,16 @@ func (self ConfigServiceBackend) Path() string {
 func (self ConfigServiceBackend) Value() interface{} {
     return self.Backend
 }
+func (self ConfigServiceBackend) Source() ConfigSource {
+    return self.ConfigSource
+}
 
 func (self ConfigRoute) Path() string {
     return makePath("routes", self.RouteName)
 }
 func (self ConfigRoute) Value() interface{} {
     return self.Route
+}
+func (self ConfigRoute) Source() ConfigSource {
+    return self.ConfigSource
 }

--- a/config/etcd.go
+++ b/config/etcd.go
@@ -105,6 +105,7 @@ func (self *Etcd) scan(node *etcd.Node, configHandler func(Config)) error {
         Path:   path,
         IsDir:  node.Dir,
         Value:  node.Value,
+        Source: EtcdConfigSource,
     }
 
     if config, err := syncConfig(configNode); err != nil {

--- a/config/files.go
+++ b/config/files.go
@@ -43,6 +43,7 @@ func (self *Files) Scan() (configs []Config, err error) {
         node := Node{
             Path:   strings.Trim(strings.TrimPrefix(path, self.config.Path), "/"),
             IsDir:  info.IsDir(),
+            Source: FileConfigSource,
         }
 
         if info.Mode().IsRegular() {

--- a/config/types.go
+++ b/config/types.go
@@ -62,6 +62,19 @@ type Config interface {
     Value() interface{}
 }
 
+/*
+ * Configuration sources: where the config is coming from
+ */
+type ConfigSource string
+
+const (
+    // A configuration from a local file
+    FileConfigSource ConfigSource = "file"
+
+    // A configuration from Etcd
+    EtcdConfigSource ConfigSource = "etcd"
+)
+
 /* Different config objects */
 
 // Used when a new service directory is created or destroyed.
@@ -69,12 +82,14 @@ type Config interface {
 // May be delievered with an empty ServiceName:"" if *all* services are to be deleted
 type ConfigService struct {
     ServiceName     string
+    ConfigSource    ConfigSource
 }
 
 type ConfigServiceFrontend struct {
     ServiceName     string
 
     Frontend        ServiceFrontend
+    ConfigSource    ConfigSource
 }
 
 // May be delivered with an empty BackendName:"" if *all* service backends are to be deleted
@@ -83,10 +98,12 @@ type ConfigServiceBackend struct {
     BackendName     string
 
     Backend         ServiceBackend
+    ConfigSource    ConfigSource
 }
 
 type ConfigRoute struct {
     RouteName       string
 
     Route           Route
+    ConfigSource    ConfigSource
 }


### PR DESCRIPTION
Add tags for all objects on where they were configured from (currently `file` or `etcd`). Only apply `DelConfig` to routes that have the matching configuration source.
