### PR TITLE
Address #7 for routes, only config those from the same source

### DIFF
--- a/route.go
+++ b/route.go
@@ -13,12 +13,13 @@ func makeRoutes() Routes {
     return Routes(make(map[string]*Route))
 }
 
-func (self Routes) get(name string) *Route {
+func (self Routes) get(name string, configSource config.ConfigSource) *Route {
     if route, exists := self[name]; exists {
         return route
     } else {
         route := &Route{
             Name: name,
+            ConfigSource: configSource,
         }
         self[name] = route
 
@@ -58,6 +59,8 @@ type Route struct {
     Gateway4        net.IP
     ipvs_fwdMethod  *ipvs.FwdMethod
     ipvs_filter     bool
+
+    ConfigSource    config.ConfigSource
 }
 
 func (self *Route) config(action config.Action, routeConfig config.Route) error {

--- a/route_test.go
+++ b/route_test.go
@@ -27,7 +27,7 @@ func TestNewConfigRoute(t *testing.T) {
     }
 
     // second round of configs from a different sources
-    services.NewConfig(&config.ConfigRoute{RouteName:""})
+    services.NewConfig(&config.ConfigRoute{RouteName:"", ConfigSource: "test"})
     route2 := services.routes["test"]
 
     if route2 == nil {

--- a/services.go
+++ b/services.go
@@ -132,7 +132,12 @@ func (self *Services) config(action config.Action, baseConfig config.Config) {
         if applyConfig.RouteName == "" {
             // all routes
             for _, route := range self.routes {
-                self.configRoute(route, action, applyConfig)
+                if route.ConfigSource == applyConfig.ConfigSource {
+                    self.configRoute(route, action, applyConfig)
+                } else {
+                    log.Printf("clusterf:config skipping route %s in wildcard routes from %s config source\n",
+                               route.Name, applyConfig.ConfigSource)
+                }
             }
         } else {
             route := self.routes.get(applyConfig.RouteName, applyConfig.ConfigSource)

--- a/services.go
+++ b/services.go
@@ -135,7 +135,7 @@ func (self *Services) config(action config.Action, baseConfig config.Config) {
                 self.configRoute(route, action, applyConfig)
             }
         } else {
-            route := self.routes.get(applyConfig.RouteName)
+            route := self.routes.get(applyConfig.RouteName, applyConfig.ConfigSource)
 
             self.configRoute(route, action, applyConfig)
         }


### PR DESCRIPTION
Add a ConfigSource to Route object. Only apply configurations to the routes coming from the same source. Fix the test case to include ConfigSource.
